### PR TITLE
Add inline style customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,31 @@ Markdown {
 ![](Sources/MarkdownUI/Documentation.docc/Resources/CustomBlockquote@2x.png#gh-light-mode-only)
 ![](Sources/MarkdownUI/Documentation.docc/Resources/CustomBlockquote~dark@2x.png#gh-dark-mode-only)
 
+You can also replace the default rendering of inline elements using the
+`markdownInlineStyle(_:body:)` modifier.
+
+```swift
+Markdown {
+  "Visit "
+  InlineLink("Swift", destination: URL(string: "https://swift.org")!)
+  " and run "
+  InlineCode("swift build")
+  "."
+}
+.markdownInlineStyle(\.inlineCode) { configuration in
+  configuration.label
+    .padding(4)
+    .background(Color.yellow.opacity(0.2))
+    .clipShape(RoundedRectangle(cornerRadius: 4))
+}
+.markdownInlineStyle(\.inlineLink) { configuration in
+  HStack(spacing: 2) {
+    configuration.label
+    Image(systemName: "link")
+  }
+}
+```
+
 Another way to customize the appearance of Markdown content is to create your own theme. To create
 a theme, start by instantiating an empty `Theme` and chain together the different text and block
 styles in a single expression.

--- a/Sources/MarkdownUI/Theme/InlineStyle/CodeInlineConfiguration.swift
+++ b/Sources/MarkdownUI/Theme/InlineStyle/CodeInlineConfiguration.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// The properties of an inline code element.
+///
+/// The ``Theme/inlineCode`` inline style receives a `CodeInlineConfiguration`
+/// value in its body closure.
+public struct CodeInlineConfiguration {
+  /// A type-erased view of an inline code element.
+  public struct Label: View {
+    init<L: View>(_ label: L) {
+      self.body = AnyView(label)
+    }
+
+    public let body: AnyView
+  }
+
+  /// The code string displayed by the inline code element.
+  public let text: String
+
+  /// The default inline code view.
+  public let label: Label
+}

--- a/Sources/MarkdownUI/Theme/InlineStyle/InlineStyle.swift
+++ b/Sources/MarkdownUI/Theme/InlineStyle/InlineStyle.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// A type that applies a custom appearance to specific inline views in a Markdown view.
+///
+/// Inline styles are used by ``Theme`` to customize the appearance of inline code or link
+/// elements. You typically don't create inline styles directly. Instead, you use the
+/// ``View/markdownInlineStyle(_:body:)`` modifier to override a particular inline style of the
+/// current theme.
+public struct InlineStyle<Configuration> {
+  private let body: (Configuration) -> AnyView
+
+  /// Creates an inline style that customizes an inline element by applying the given body.
+  /// - Parameter body: A view builder that receives the inline configuration and returns the
+  ///   customized view.
+  public init<Body: View>(@ViewBuilder body: @escaping (_ configuration: Configuration) -> Body) {
+    self.body = { AnyView(body($0)) }
+  }
+
+  func makeBody(configuration: Configuration) -> AnyView {
+    self.body(configuration)
+  }
+}
+
+extension InlineStyle where Configuration == Void {
+  /// Creates an inline style for an inline element with no configuration.
+  /// - Parameter body: A view builder that returns the customized inline element.
+  public init<Body: View>(@ViewBuilder body: @escaping () -> Body) {
+    self.init { _ in body() }
+  }
+}

--- a/Sources/MarkdownUI/Theme/InlineStyle/LinkInlineConfiguration.swift
+++ b/Sources/MarkdownUI/Theme/InlineStyle/LinkInlineConfiguration.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// The properties of a Markdown link inline element.
+///
+/// The ``Theme/inlineLink`` inline style receives a `LinkInlineConfiguration`
+/// value in its body closure.
+public struct LinkInlineConfiguration {
+  /// A type-erased view of a link label.
+  public struct Label: View {
+    init<L: View>(_ label: L) {
+      self.body = AnyView(label)
+    }
+
+    public let body: AnyView
+  }
+
+  /// The link destination URL string.
+  public let destination: String
+
+  /// The plain text contents of the link.
+  public let text: String
+
+  /// The default link view.
+  public let label: Label
+}

--- a/Sources/MarkdownUI/Theme/Theme.swift
+++ b/Sources/MarkdownUI/Theme/Theme.swift
@@ -118,6 +118,12 @@ public struct Theme: Sendable {
   /// The link style.
   public var link: TextStyle = EmptyTextStyle()
 
+  /// The inline code style.
+  public var inlineCode = InlineStyle<CodeInlineConfiguration> { $0.label }
+
+  /// The inline link style.
+  public var inlineLink = InlineStyle<LinkInlineConfiguration> { $0.label }
+
   var headings = Array(
     repeating: BlockStyle<BlockConfiguration> { $0.label },
     count: 6
@@ -213,6 +219,26 @@ extension Theme {
   public func code<S: TextStyle>(@TextStyleBuilder code: () -> S) -> Theme {
     var theme = self
     theme.code = code()
+    return theme
+  }
+
+  /// Adds an inline code style to the theme.
+  /// - Parameter body: A view builder that returns the customized inline code view.
+  public func inlineCode<Body: View>(
+    @ViewBuilder body: @escaping (_ configuration: CodeInlineConfiguration) -> Body
+  ) -> Theme {
+    var theme = self
+    theme.inlineCode = .init(body: body)
+    return theme
+  }
+
+  /// Adds an inline link style to the theme.
+  /// - Parameter body: A view builder that returns the customized inline link view.
+  public func inlineLink<Body: View>(
+    @ViewBuilder body: @escaping (_ configuration: LinkInlineConfiguration) -> Body
+  ) -> Theme {
+    var theme = self
+    theme.inlineLink = .init(body: body)
     return theme
   }
 

--- a/Sources/MarkdownUI/Views/Environment/Environment+Theme.swift
+++ b/Sources/MarkdownUI/Views/Environment/Environment+Theme.swift
@@ -40,6 +40,30 @@ extension View {
     self.environment((\EnvironmentValues.theme).appending(path: keyPath), .init(body: body))
   }
 
+  /// Replaces a specific inline style on the current ``Theme`` with an inline style
+  /// initialized with the given body closure.
+  /// - Parameters:
+  ///   - keyPath: The ``Theme`` key path to the inline style to replace.
+  ///   - body: A view builder that receives the inline configuration and returns the customized inline view.
+  public func markdownInlineStyle<Configuration, Body: View>(
+    _ keyPath: WritableKeyPath<Theme, InlineStyle<Configuration>>,
+    @ViewBuilder body: @escaping (_ configuration: Configuration) -> Body
+  ) -> some View {
+    self.environment((\EnvironmentValues.theme).appending(path: keyPath), .init(body: body))
+  }
+
+  /// Replaces a specific inline style on the current ``Theme`` with an inline style
+  /// initialized with the given body closure.
+  /// - Parameters:
+  ///   - keyPath: The ``Theme`` key path to the inline style to replace.
+  ///   - body: A view builder that returns the customized inline view.
+  public func markdownInlineStyle<Body: View>(
+    _ keyPath: WritableKeyPath<Theme, InlineStyle<Void>>,
+    @ViewBuilder body: @escaping () -> Body
+  ) -> some View {
+    self.environment((\EnvironmentValues.theme).appending(path: keyPath), .init(body: body))
+  }
+
   /// Replaces the current ``Theme`` task list marker with the given list marker.
   public func markdownTaskListMarker(
     _ value: BlockStyle<TaskListMarkerConfiguration>

--- a/Sources/MarkdownUI/Views/Inlines/InlineText.swift
+++ b/Sources/MarkdownUI/Views/Inlines/InlineText.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Foundation
 
 struct InlineText: View {
   @Environment(\.inlineImageProvider) private var inlineImageProvider
@@ -17,19 +18,30 @@ struct InlineText: View {
 
   var body: some View {
     TextStyleAttributesReader { attributes in
-      self.inlines.renderText(
-        baseURL: self.baseURL,
-        textStyles: .init(
-          code: self.theme.code,
-          emphasis: self.theme.emphasis,
-          strong: self.theme.strong,
-          strikethrough: self.theme.strikethrough,
-          link: self.theme.link
-        ),
-        images: self.inlineImages,
-        softBreakMode: self.softBreakMode,
-        attributes: attributes
-      )
+      if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+        let renderer = InlineViewRenderer(
+          baseURL: self.baseURL,
+          theme: self.theme,
+          images: self.inlineImages,
+          softBreakMode: self.softBreakMode,
+          attributes: attributes
+        )
+        InlineFlow(items: renderer.render(self.inlines))
+      } else {
+        self.inlines.renderText(
+          baseURL: self.baseURL,
+          textStyles: .init(
+            code: self.theme.code,
+            emphasis: self.theme.emphasis,
+            strong: self.theme.strong,
+            strikethrough: self.theme.strikethrough,
+            link: self.theme.link
+          ),
+          images: self.inlineImages,
+          softBreakMode: self.softBreakMode,
+          attributes: attributes
+        )
+      }
     }
     .task(id: self.inlines) {
       self.inlineImages = (try? await self.loadInlineImages()) ?? [:]
@@ -61,3 +73,169 @@ struct InlineText: View {
     }
   }
 }
+
+#if swift(>=5.7)
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+private struct InlineFlow: View {
+  let items: [AnyView]
+
+  var body: some View {
+    FlowLayout(horizontalSpacing: 0, verticalSpacing: 0) {
+      ForEach(Array(self.items.enumerated()), id: \.0) { _, item in
+        item
+      }
+    }
+  }
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+private struct InlineViewRenderer {
+  let baseURL: URL?
+  let theme: Theme
+  let images: [String: Image]
+  let softBreakMode: SoftBreak.Mode
+  var attributes: AttributeContainer
+  var shouldSkipNextWhitespace = false
+
+  func render(_ inlines: [InlineNode]) -> [AnyView] {
+    var renderer = self
+    renderer.render(inlines)
+    return renderer.result
+  }
+
+  private var result: [AnyView] = []
+
+  private mutating func render(_ inlines: [InlineNode]) {
+    for inline in inlines {
+      self.render(inline)
+    }
+  }
+
+  private mutating func render(_ inline: InlineNode) {
+    switch inline {
+    case .text(let content):
+      self.renderText(content)
+    case .softBreak:
+      self.renderSoftBreak()
+    case .lineBreak:
+      self.renderLineBreak()
+    case .code(let content):
+      self.renderCode(content)
+    case .html(let content):
+      self.renderHTML(content)
+    case .emphasis(let children):
+      self.renderEmphasis(children: children)
+    case .strong(let children):
+      self.renderStrong(children: children)
+    case .strikethrough(let children):
+      self.renderStrikethrough(children: children)
+    case .link(let destination, let children):
+      self.renderLink(destination: destination, children: children)
+    case .image(let source, _):
+      self.renderImage(source: source)
+    }
+  }
+
+  private mutating func renderText(_ text: String) {
+    var text = text
+    if self.shouldSkipNextWhitespace {
+      self.shouldSkipNextWhitespace = false
+      text = text.replacingOccurrences(of: "^\\s+", with: "", options: .regularExpression)
+    }
+    self.result.append(AnyView(Text(AttributedString(text, attributes: self.attributes))))
+  }
+
+  private mutating func renderSoftBreak() {
+    switch self.softBreakMode {
+    case .space where self.shouldSkipNextWhitespace:
+      self.shouldSkipNextWhitespace = false
+    case .space:
+      self.result.append(AnyView(Text(" ")))
+    case .lineBreak:
+      self.renderLineBreak()
+    }
+  }
+
+  private mutating func renderLineBreak() {
+    self.shouldSkipNextWhitespace = true
+    self.result.append(AnyView(Spacer().layoutPriority(-1)))
+  }
+
+  private mutating func renderCode(_ code: String) {
+    var attributes = self.attributes
+    self.theme.code._collectAttributes(in: &attributes)
+    let label = Text(AttributedString(code, attributes: attributes))
+    let configuration = CodeInlineConfiguration(text: code, label: .init(label))
+    self.result.append(self.theme.inlineCode.makeBody(configuration: configuration))
+  }
+
+  private mutating func renderHTML(_ html: String) {
+    let tag = HTMLTag(html)
+    switch tag?.name.lowercased() {
+    case "br":
+      self.renderLineBreak()
+    default:
+      self.renderText(html)
+    }
+  }
+
+  private mutating func renderEmphasis(children: [InlineNode]) {
+    let savedAttributes = self.attributes
+    self.attributes = self.theme.emphasis.mergingAttributes(self.attributes)
+    for child in children { self.render(child) }
+    self.attributes = savedAttributes
+  }
+
+  private mutating func renderStrong(children: [InlineNode]) {
+    let savedAttributes = self.attributes
+    self.attributes = self.theme.strong.mergingAttributes(self.attributes)
+    for child in children { self.render(child) }
+    self.attributes = savedAttributes
+  }
+
+  private mutating func renderStrikethrough(children: [InlineNode]) {
+    let savedAttributes = self.attributes
+    self.attributes = self.theme.strikethrough.mergingAttributes(self.attributes)
+    for child in children { self.render(child) }
+    self.attributes = savedAttributes
+  }
+
+  private mutating func renderLink(destination: String, children: [InlineNode]) {
+    let savedAttributes = self.attributes
+    self.attributes = self.theme.link.mergingAttributes(self.attributes)
+    self.attributes.link = URL(string: destination, relativeTo: self.baseURL)
+    var childRenderer = InlineViewRenderer(
+      baseURL: self.baseURL,
+      theme: self.theme,
+      images: self.images,
+      softBreakMode: self.softBreakMode,
+      attributes: self.attributes
+    )
+    let childItems = childRenderer.render(children)
+    let label = InlineFlow(items: childItems)
+    let configuration = LinkInlineConfiguration(
+      destination: destination,
+      text: children.renderPlainText(),
+      label: .init(label)
+    )
+    self.result.append(self.theme.inlineLink.makeBody(configuration: configuration))
+    self.attributes = savedAttributes
+  }
+
+  private mutating func renderImage(source: String) {
+    if let image = self.images[source] {
+      self.result.append(AnyView(image))
+    }
+  }
+}
+#endif
+
+#if swift(>=5.7)
+extension TextStyle {
+  fileprivate func mergingAttributes(_ attributes: AttributeContainer) -> AttributeContainer {
+    var newAttributes = attributes
+    self._collectAttributes(in: &newAttributes)
+    return newAttributes
+  }
+}
+#endif


### PR DESCRIPTION
## Summary
- add new `InlineStyle` infrastructure and configuration types
- extend `Theme` with `inlineCode` and `inlineLink` styles
- provide environment modifiers for overriding inline styles
- rework `InlineText` to use new inline renderer when available
- document customizing inline code and links

## Testing
- `swift test -c debug` *(fails: Failed to clone repository)*